### PR TITLE
Critical fix

### DIFF
--- a/src/astroprint/printerprofile/__init__.py
+++ b/src/astroprint/printerprofile/__init__.py
@@ -29,7 +29,7 @@ class PrinterProfileManager(object):
 			'max_nozzle_temp': 280,
 			'max_bed_temp': 140,
 			'heated_bed': True,
-			'cancel_gcode': ['G28']
+			'cancel_gcode': ['G28 X0 Y0']
 		}
 
 		if not os.path.isfile(self._infoFile):


### PR DESCRIPTION
This critical fix, because if we use G28, Z axis go to home too and printer will destroy self (ex: Prusa i3).