### PR TITLE
Fixed heatingUp false on initial_state for virtual

### DIFF
--- a/src/astroprint/printer/plugin/__init__.py
+++ b/src/astroprint/printer/plugin/__init__.py
@@ -298,7 +298,7 @@ class PrinterWithPlugin(Printer):
 		return self._plugin.streaming
 
 	def isHeatingUp(self):
-		return self._plugin.preHeating
+		return self._plugin.heatingUp
 
 	def isConnected(self):
 		return self._plugin.connected

--- a/src/plugins/com_astroprint_astrobox_plugins_virtualcomms/__init__.py
+++ b/src/plugins/com_astroprint_astrobox_plugins_virtualcomms/__init__.py
@@ -212,8 +212,8 @@ class VirtualComms(Plugin, PrinterCommsService):
 		return self._comm
 
 	@property
-	def preHeating(self):
-		return self._preheating
+	def heatingUp(self):
+		return self._heatingUp
 
 	@property
 	def printProgress(self):


### PR DESCRIPTION
Using virtual printer with plugin.
While printer is heating up , the initial_state request will return a FALSE.