### PR TITLE
Julian fix event shutdown

### DIFF
--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -167,7 +167,6 @@ def apiVersion():
 #@restricted_access
 #@admin_permission.require(403)
 def performSystemAction():
-	print "perormSystemAction"
 	if "action" in request.values.keys():
 		action = request.values["action"]
 		available_actions = s().get(["system", "actions"])
@@ -181,11 +180,9 @@ def performSystemAction():
 
 					def executeCommand(command, logger):
 						timeSleeping = 0.5
-						print "executeCommand"
 						#if shutdown send message to plugin
-						if command == "reboot" or command == "shutdown":
-							print command
-							eventManager().fire(Events.SHUTTING_DOWN, {'status': command})
+						if action == "reboot" or action == "shutdown":
+							eventManager().fire(Events.SHUTTING_DOWN, {'status': action})
 							timeSleeping = 1
 						time.sleep(timeSleeping) #add a small delay to make sure the response is sent
 

--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -192,7 +192,7 @@ def performSystemAction():
 								returncode = p.returncode
 								stderr_text = p.stderr.text
 								logger.warn("Command failed with return code %i: %s" % (returncode, stderr_text))
-								if command == "reboot" or command == "shutdown":
+								if action == "reboot" or action == "shutdown":
 									eventManager().fire(Events.SHUTTING_DOWN, {'status': None})
 							else:
 								logger.info("Command executed sucessfully")

--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -179,11 +179,13 @@ def performSystemAction():
 					logger.info("Performing command: %s" % command)
 
 					def executeCommand(command, logger):
-						time.sleep(0.5) #add a small delay to make sure the response is sent
-
+						timeSleeping = 0.5
 						#if shutdown send message to plugin
 						if command == "reboot" or command == "shutdown":
 							eventManager().fire(Events.SHUTTING_DOWN, {'status': command})
+							timeSleeping = 1
+						time.sleep(timeSleeping) #add a small delay to make sure the response is sent
+
 						try:
 							p = sarge.run(command, stderr=sarge.Capture())
 							if p.returncode != 0:

--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -167,6 +167,7 @@ def apiVersion():
 #@restricted_access
 #@admin_permission.require(403)
 def performSystemAction():
+	print "perormSystemAction"
 	if "action" in request.values.keys():
 		action = request.values["action"]
 		available_actions = s().get(["system", "actions"])
@@ -180,8 +181,10 @@ def performSystemAction():
 
 					def executeCommand(command, logger):
 						timeSleeping = 0.5
+						print "executeCommand"
 						#if shutdown send message to plugin
 						if command == "reboot" or command == "shutdown":
+							print command
 							eventManager().fire(Events.SHUTTING_DOWN, {'status': command})
 							timeSleeping = 1
 						time.sleep(timeSleeping) #add a small delay to make sure the response is sent


### PR DESCRIPTION
When astrobox is running in mac, "action" and "command" params return the same output: shutdown or reboot. In a real device "command" includes the path to run the action, so the one to use is "action". 

This fixes https://github.com/CoDanny/AstroBox-Touch/issues/572