### PR TITLE
Fix astroprint 2760

### DIFF
--- a/src/astroprint/printer/__init__.py
+++ b/src/astroprint/printer/__init__.py
@@ -501,11 +501,11 @@ class Printer(object):
 		c = cameraManager()
 		freq = s.get(['camera', 'freq'])
 
-		if freq and c.isCameraConnected():
-			c.start_timelapse(freq)
-
 		if result and "id" in result:
 			self._currentPrintJobId = result['id']
+
+		if freq and c.isCameraConnected():
+			c.start_timelapse(freq)
 
 		self._timeStarted = time.time()
 		self._secsPaused = 0


### PR DESCRIPTION
Astrobox was creating time lapses without having the print_job_id yet, that cause an astroprint issue:

https://github.com/CoDanny/astroprint/issues/2706