### PR TITLE
Added cloud_job_id to job info request

### DIFF
--- a/src/astroprint/boxrouter/handlers/requesthandler.py
+++ b/src/astroprint/boxrouter/handlers/requesthandler.py
@@ -60,7 +60,14 @@ class RequestHandler(object):
 		done(state)
 
 	def job_info(self, data, clientId, done):
-		done(printerManager()._stateMonitor._jobData)
+		printer = printerManager()
+		jobData = printer._stateMonitor._jobData
+
+		if jobData is not None:
+			jobData.update({
+				'cloud_job_id': printer.currentPrintJobId
+			})
+		done(jobData)
 
 	def printerCommand(self, data, clientId, done):
 		self._handleCommandGroup(PrinterCommandHandler, data, clientId, done)


### PR DESCRIPTION
We previously added to job data for initial state request, so it makes sense to keep consistency.